### PR TITLE
BLE: Fix packet loss in HCI driver.

### DIFF
--- a/BlueNrgHCIDriver.cpp
+++ b/BlueNrgHCIDriver.cpp
@@ -510,8 +510,6 @@ private:
         uint16_t read_length = 0;
         uint16_t data_available = 0;
 
-        _spi_mutex.lock();
-
         nCS = 0;
 
         /* Read the header */
@@ -532,7 +530,6 @@ private:
 
     exit:
         nCS = 1;
-        _spi_mutex.unlock();
 
         return read_length;
     }
@@ -550,10 +547,13 @@ private:
         uint8_t data_buffer[256];
         while(true) {
             _spi_read_sem.wait();
+
+            _spi_mutex.lock();
             while(irq == 1) {
                 uint16_t data_read = spiRead(data_buffer, sizeof(data_buffer));
                 on_data_received(data_buffer, data_read);
             }
+            _spi_mutex.unlock();
         }
     }
 


### PR DESCRIPTION
Basically, disabling the interrupt is not required any more. 

It can cause issues if the reading thread is on but not reading SPI (mutex unlocked) and in the main thread we start a write. 
