### PR TITLE
Add get_buffer_pool_description() definition for Mbed OS 5.11 and onwards

### DIFF
--- a/BlueNrgHCIDriver.cpp
+++ b/BlueNrgHCIDriver.cpp
@@ -49,6 +49,15 @@ public:
     HCIDriver(cordio::CordioHCITransportDriver& transport_driver, PinName rst) :
         cordio::CordioHCIDriver(transport_driver), rst(rst) { }
 
+#if MBED_VERSION >= MBED_ENCODE_VERSION(5, 11, 0)
+    /**
+     * @see CordioHCIDriver::get_buffer_pool_description
+     */
+    virtual cordio::buf_pool_desc_t get_buffer_pool_description() {
+        return get_default_buffer_pool_description();
+    }
+#endif
+
     /**
      * @see CordioHCIDriver::do_initialize
      */


### PR DESCRIPTION
Update driver according to https://github.com/ARMmbed/mbed-os/pull/8981 (preceding PR)