### PR TITLE
Add missing Apache v2 header

### DIFF
--- a/BlueNrgHCIDriver.cpp
+++ b/BlueNrgHCIDriver.cpp
@@ -1,3 +1,19 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2019 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <stdio.h>
 #include "CordioBLE.h"
 #include "CordioHCIDriver.h"


### PR DESCRIPTION
Add Apache v2 license header to `BlueNrgHCIDriver.cpp`
Note: `bluenrg_targets.h` is owned by ST.

@pan- Could you check if the license years are correct?