### PR TITLE
Replace deprecated Gap::setAddress with Gap::set_random_static_address

### DIFF
--- a/BlueNrgHCIDriver.cpp
+++ b/BlueNrgHCIDriver.cpp
@@ -132,10 +132,7 @@ public:
 
             case ACI_READ_CONFIG_DATA_OPCODE:
                 // note: will send the HCI command to send the random address
-                cordio::BLE::deviceInstance().getGap().setAddress(
-                    BLEProtocol::AddressType::RANDOM_STATIC,
-                    pMsg
-                );
+                set_random_static_address(pMsg);
                 break;
 
             case HCI_OPCODE_LE_SET_RAND_ADDR:


### PR DESCRIPTION
Reviewers
@pan- @paul-szczepanek-arm 

TO BE MERGED AFTER https://github.com/ARMmbed/mbed-os/pull/12321/ AND `./mbed_lib.json` TO BE UPDATED TO POINT TO THE CORRECT VERSION THAT IMPLEMENTS THE NEW API.